### PR TITLE
Remove DependencyInfoBlock for F-Droid

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,13 @@ android {
         }
     }
 
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
+
     signingConfigs {
         create("release") {
             storeFile = file("../pipixiv.jks")


### PR DESCRIPTION
We find that there is a `DependencyInfoBlock` in your APK.

It's a [Signing block](https://bi-zone.medium.com/easter-egg-in-apk-files-what-is-frosting-f356aa9f4d1) added by AGP and encrypted with the Google public key so it can't be read by anyone else except Google. You can read more about it [here](https://gitlab.com/fdroid/admin/-/issues/367) and [here](https://gitlab.com/fdroid/fdroidserver/-/issues/1056).

