### PR TITLE
Disable dependency info block

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,13 @@ android {
         }
     }
 
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
+
     flavorDimensions += "version"
     productFlavors {
         create("default") {


### PR DESCRIPTION
It's a [Signing block](https://source.android.com/docs/security/features/apksigning/v2#apk-signing-block) added by AGP and encrypted with the Google public key so it can't be read by anyone else except Google. You can read more about it [here](https://gitlab.com/fdroid/admin/-/issues/367), [here](https://gitlab.com/fdroid/fdroidserver/-/issues/1056) and [here](https://android.izzysoft.de/articles/named/iod-scan-apkchecks?lang=en#blobs).

